### PR TITLE
Implement group-aware sticky quota routing with live threshold controls and dashboard routing visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,20 @@ JWT_SECRET=change-me-too
 # 冷却时间上限（毫秒）
 # CAPACITY_COOLDOWN_MAX_MS=120000
 
+# ============ Quota Routing Thresholds (Live Config) ============
+# Values are fractions: 0.2 means 20%
+# Requests stay on the same account per group until quota reaches threshold,
+# then switch to another account in that group.
+
+# Global fallback threshold (default: 0.2)
+# GROUP_QUOTA_MIN_THRESHOLD=0.2
+
+# Per-group threshold overrides (optional)
+# FLASH_GROUP_QUOTA_MIN_THRESHOLD=0.2
+# PRO_GROUP_QUOTA_MIN_THRESHOLD=0.2
+# CLAUDE_GROUP_QUOTA_MIN_THRESHOLD=0.2
+# IMAGE_GROUP_QUOTA_MIN_THRESHOLD=0.2
+
 # ============ 网络代理 ============
 # 出站 HTTP(S) 代理（解决部分网络环境下 OAuth/Token 刷新超时问题）
 # OUTBOUND_PROXY=http://127.0.0.1:7890

--- a/backend/public/components/dashboard.js
+++ b/backend/public/components/dashboard.js
@@ -4,12 +4,13 @@
 
 import { Component } from '../core/component.js';
 import { store } from '../core/store.js';
+import { commands } from '../commands/index.js';
 import { formatNumber } from '../utils/format.js';
 
 export class Dashboard extends Component {
   render() {
     const dashboard = store.get('dashboard') || {};
-    const { data, loading } = dashboard;
+    const { data, loading, settings = {}, settingsSaving = false, settingsLoading = false } = dashboard;
     
     if (loading && !data) {
       return `
@@ -25,6 +26,7 @@ export class Dashboard extends Component {
     const accounts = d.accounts || {};
     const pool = d.pool || {};
     const modelUsage = Array.isArray(d.modelUsage) ? d.modelUsage : [];
+    const routing = Array.isArray(d.routing) ? d.routing : [];
 
     return `
       <div class="dashboard-page">
@@ -66,9 +68,136 @@ export class Dashboard extends Component {
               ${this._renderEndpoint('Anthropic 兼容', `${location.origin}/v1/messages`)}
             </div>
           </div>
+
+          <div class="card dashboard-settings-card">
+            <div class="card-header">
+              <span class="card-title">Quota Thresholds</span>
+            </div>
+            ${this._renderThresholdEditor(settings, { settingsSaving, settingsLoading })}
+          </div>
+
+          <div class="card dashboard-routing-card">
+            <div class="card-header">
+              <span class="card-title">Current Routing</span>
+            </div>
+            ${this._renderRoutingOverview(routing)}
+          </div>
         </div>
       </div>
     `;
+  }
+
+  _renderRoutingOverview(routing) {
+    if (!routing.length) {
+      return `
+        <div class="text-secondary text-center" style="padding:20px 0">
+          No routing data yet
+        </div>
+      `;
+    }
+
+    return `
+      <div class="routing-list">
+        ${routing.map((item) => {
+          const current = item?.currentAccount;
+          const sticky = item?.sticky;
+          const accountText = current?.email || (current?.id ? `#${current.id}` : '-');
+          const quotaText = Number.isFinite(Number(current?.quotaRemaining))
+            ? `${this._formatPercent(Number(current.quotaRemaining))}`
+            : '-';
+          const stickyText = sticky?.id
+            ? `${sticky?.email || `#${sticky.id}`}${sticky?.switchRequired ? ' -> switch pending' : ''}`
+            : 'not set';
+
+          return `
+            <div class="routing-item">
+              <div class="routing-group">${this._escape(this._formatGroupName(item?.group))}</div>
+              <div class="routing-account mono">${this._escape(accountText)}</div>
+              <div class="routing-meta">quota ${this._escape(quotaText)} | threshold ${this._escape(this._formatPercent(item?.threshold))}</div>
+              <div class="routing-sticky text-secondary">sticky: ${this._escape(stickyText)}</div>
+            </div>
+          `;
+        }).join('')}
+      </div>
+    `;
+  }
+
+  _formatGroupName(group) {
+    const key = String(group || '').toLowerCase();
+    if (key === 'flash') return 'Gemini Flash';
+    if (key === 'pro') return 'Gemini Pro';
+    if (key === 'claude') return 'Claude';
+    if (key === 'image') return 'Image';
+    return key || 'Unknown';
+  }
+
+  _formatPercent(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '-';
+    const clamped = Math.max(0, Math.min(1, n));
+    const pct = clamped * 100;
+    return Number.isInteger(pct) ? `${pct}%` : `${pct.toFixed(1)}%`;
+  }
+
+  _renderThresholdEditor(settings, { settingsSaving = false, settingsLoading = false } = {}) {
+    const global = this._toPercent(settings.global);
+    const flash = this._toPercent(settings.flash);
+    const pro = this._toPercent(settings.pro);
+    const claude = this._toPercent(settings.claude);
+    const image = this._toPercent(settings.image);
+    const disabledAttr = settingsSaving || settingsLoading ? 'disabled' : '';
+    const buttonLabel = settingsSaving ? 'Saving...' : 'Save Thresholds';
+
+    return `
+      <form class="threshold-form" data-settings-form>
+        <div class="threshold-hint text-secondary">
+          Per-group switch threshold (%). Requests stay on the same account for that group until threshold is reached.
+        </div>
+        <div class="threshold-grid">
+          ${this._renderThresholdField('Global fallback', 'global', global, disabledAttr)}
+          ${this._renderThresholdField('Gemini Flash', 'flash', flash, disabledAttr)}
+          ${this._renderThresholdField('Gemini Pro', 'pro', pro, disabledAttr)}
+          ${this._renderThresholdField('Claude', 'claude', claude, disabledAttr)}
+          ${this._renderThresholdField('Image', 'image', image, disabledAttr)}
+        </div>
+        <div class="threshold-actions">
+          <button class="btn btn-primary" type="submit" ${disabledAttr}>${buttonLabel}</button>
+        </div>
+      </form>
+    `;
+  }
+
+  _renderThresholdField(label, key, value, disabledAttr = '') {
+    return `
+      <label class="form-group">
+        <span class="form-label">${this._escape(label)}</span>
+        <input
+          class="form-input"
+          type="number"
+          min="0"
+          max="100"
+          step="0.1"
+          name="${this._escape(key)}"
+          value="${value}"
+          ${disabledAttr}
+        />
+      </label>
+    `;
+  }
+
+  _toPercent(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return '20';
+    const clamped = Math.max(0, Math.min(1, n));
+    const pct = clamped * 100;
+    return Number.isInteger(pct) ? String(pct) : pct.toFixed(1);
+  }
+
+  _parsePercentToFraction(raw, fallback = 0.2) {
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return fallback;
+    const clampedPct = Math.max(0, Math.min(100, n));
+    return clampedPct / 100;
   }
 
   _renderStatCard(title, value, subtitle, valueClass = '') {
@@ -121,6 +250,26 @@ export class Dashboard extends Component {
         <span class="endpoint-url">${this._escape(url)}</span>
       </div>
     `;
+  }
+
+  _bindEvents() {
+    this.on('form[data-settings-form]', 'submit', async (e) => {
+      e.preventDefault();
+      const form = e.currentTarget;
+      if (!(form instanceof HTMLFormElement)) return;
+
+      const data = new FormData(form);
+      const current = store.get('dashboard.settings') || {};
+      const thresholds = {
+        global: this._parsePercentToFraction(data.get('global'), Number(current.global ?? 0.2)),
+        flash: this._parsePercentToFraction(data.get('flash'), Number(current.flash ?? 0.2)),
+        pro: this._parsePercentToFraction(data.get('pro'), Number(current.pro ?? 0.2)),
+        claude: this._parsePercentToFraction(data.get('claude'), Number(current.claude ?? 0.2)),
+        image: this._parsePercentToFraction(data.get('image'), Number(current.image ?? 0.2))
+      };
+
+      await commands.dispatch('dashboard:save-thresholds', { thresholds });
+    });
   }
 
   onMount() {

--- a/backend/public/core/store.js
+++ b/backend/public/core/store.js
@@ -210,7 +210,16 @@ export const store = new Store({
   dashboard: {
     data: null,
     loading: false,
-    error: null
+    error: null,
+    settings: {
+      global: 0.2,
+      flash: 0.2,
+      pro: 0.2,
+      claude: 0.2,
+      image: 0.2
+    },
+    settingsLoading: false,
+    settingsSaving: false
   },
   
   // 账号管理

--- a/backend/public/services/api.js
+++ b/backend/public/services/api.js
@@ -240,6 +240,19 @@ class ApiService {
     });
   }
 
+  async getSettings() {
+    return this.request('/admin/settings', {
+      dedupKey: 'admin-settings'
+    });
+  }
+
+  async updateSetting(key, value) {
+    return this.request('/admin/settings', {
+      method: 'PUT',
+      body: { key, value }
+    });
+  }
+
   // ============ 账号 API ============
 
   async getAccounts() {

--- a/backend/public/styles.css
+++ b/backend/public/styles.css
@@ -532,8 +532,77 @@ body {
   flex: 1;
 }
 
+.dashboard-settings-card {
+  min-height: auto !important;
+}
+
+.threshold-form {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.threshold-hint {
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.threshold-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.threshold-grid .form-label {
+  text-transform: none;
+}
+
+.threshold-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dashboard-routing-card {
+  min-height: auto !important;
+}
+
+.routing-list {
+  display: grid;
+  gap: 10px;
+}
+
+.routing-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  background: var(--color-surface-2);
+}
+
+.routing-group {
+  font-weight: 600;
+}
+
+.routing-account {
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+.routing-meta,
+.routing-sticky {
+  margin-top: 3px;
+  font-size: 12px;
+}
+
 @media (max-width: 1000px) {
   .content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .threshold-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -132,6 +132,13 @@ export const MODEL_MAPPING = {
     'gemini-pro': 'gemini-2.5-pro'
 };
 
+export const QUOTA_GROUPS = Object.freeze({
+    FLASH: 'flash',
+    PRO: 'pro',
+    CLAUDE: 'claude',
+    IMAGE: 'image'
+});
+
 // 默认启用思维链的模型
 export const THINKING_MODELS = [
     'gemini-2.5-pro',
@@ -159,6 +166,43 @@ export function isImageGenerationModel(model) {
 // 获取实际发送的模型名称
 export function getMappedModel(model) {
     return MODEL_MAPPING[model] || model;
+}
+
+export function getQuotaGroup(model) {
+    const mapped = String(getMappedModel(model) || '').trim().toLowerCase();
+    if (!mapped) return null;
+
+    if (mapped.includes('image')) return QUOTA_GROUPS.IMAGE;
+    if (mapped.includes('claude')) return QUOTA_GROUPS.CLAUDE;
+    if (mapped.includes('gemini') && mapped.includes('pro')) return QUOTA_GROUPS.PRO;
+    if (mapped.includes('gemini') && mapped.includes('flash')) return QUOTA_GROUPS.FLASH;
+    return null;
+}
+
+function clampFraction(value, fallback = 0) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return fallback;
+    return Math.max(0, Math.min(1, n));
+}
+
+export function getGroupQuotaThreshold(group = null) {
+    const globalThreshold = clampFraction(process.env.GROUP_QUOTA_MIN_THRESHOLD ?? 0.2, 0.2);
+    const key = String(group || '').trim().toLowerCase();
+    if (!key) return globalThreshold;
+
+    if (key === QUOTA_GROUPS.FLASH) {
+        return clampFraction(process.env.FLASH_GROUP_QUOTA_MIN_THRESHOLD ?? globalThreshold, globalThreshold);
+    }
+    if (key === QUOTA_GROUPS.PRO) {
+        return clampFraction(process.env.PRO_GROUP_QUOTA_MIN_THRESHOLD ?? globalThreshold, globalThreshold);
+    }
+    if (key === QUOTA_GROUPS.CLAUDE) {
+        return clampFraction(process.env.CLAUDE_GROUP_QUOTA_MIN_THRESHOLD ?? globalThreshold, globalThreshold);
+    }
+    if (key === QUOTA_GROUPS.IMAGE) {
+        return clampFraction(process.env.IMAGE_GROUP_QUOTA_MIN_THRESHOLD ?? globalThreshold, globalThreshold);
+    }
+    return globalThreshold;
 }
 
 // Safety settings：完整版（11 类）和基础版（5 类）

--- a/backend/src/routes/openai.js
+++ b/backend/src/routes/openai.js
@@ -12,7 +12,7 @@ import {
 import { createRequestLog } from '../db/index.js';
 import { isThinkingModel } from '../config.js';
 import { logModelCall } from '../services/modelLogger.js';
-import { isCapacityError, isAuthenticationError, parseResetAfterMs, SSE_HEADERS, buildErrorMessage } from '../utils/route-helpers.js';
+import { isCapacityError, isAuthenticationError, isServerCapacityExhaustedError, parseResetAfterMs, SSE_HEADERS, buildErrorMessage } from '../utils/route-helpers.js';
 import { createAbortController, runChatWithFullRetry, runStreamChatWithFullRetry } from '../utils/request-handler.js';
 import { sendTrajectoryAnalytics } from '../services/trajectory.js';
 import { sendRequestMetrics } from '../services/telemetry.js';
@@ -227,14 +227,15 @@ export default async function openaiRoutes(fastify) {
             errorMessage = buildErrorMessage(error);
 
             const capacity = isCapacityError(error);
+            const serverCapacityExhausted = isServerCapacityExhaustedError(error);
             const authError = isAuthenticationError(error);
             const retryAfterMs = Number.isFinite(error?.retryAfterMs)
                 ? error.retryAfterMs
                 : parseResetAfterMs(error?.message);
 
-            if (account && capacity) {
+            if (account && capacity && !serverCapacityExhausted) {
                 accountPool.markCapacityLimited(account.id, model, error.message || '');
-            } else if (account && !authError && !error?.authHandled) {
+            } else if (account && !capacity && !authError && !error?.authHandled) {
                 accountPool.markAccountError(account.id, error);
             }
 

--- a/backend/src/services/antigravity.js
+++ b/backend/src/services/antigravity.js
@@ -155,7 +155,12 @@ export async function streamChat(account, request, onData, onError, signal = nul
                 const blockReason = promptFeedback?.blockReason || promptFeedback?.blockReasonMessage;
 
                 if (upstreamError?.message) {
-                    throw new Error(upstreamError.message);
+                    const err = new Error(upstreamError.message);
+                    const code = Number(upstreamError?.code);
+                    if (Number.isFinite(code)) err.upstreamStatus = code;
+                    err.upstreamJson = parsed;
+                    err.upstreamBody = payload;
+                    throw err;
                 }
                 if (blockReason) {
                     throw new Error(`Upstream blocked request: ${blockReason}`);


### PR DESCRIPTION
## Summary
- Replace global round-robin selection with group-aware sticky routing (`flash`, `pro`, `claude`, `image`) backed by group pseudo-quotas in `account_model_quotas`.
- Add live quota-threshold settings (global + per-group) with DB persistence and env fallback inheritance, and expose editable controls on the dashboard.
- Enforce strict eligibility as `quota_remaining > threshold` for all thresholds (including `0`), returning capacity-style 429 when no account is eligible.
- Surface current sticky routing state on dashboard (`group -> current account`) and mark when sticky account is no longer eligible and switch is pending.
- Keep failover behavior safe: if sticky account is disabled/error/cooldown/refresh-invalid, routing automatically falls through to the next eligible account.

## Key Implementation Details
- Persist group quota rows as pseudo-model keys (`group:flash`, `group:pro`, `group:claude`, `group:image`) during quota sync using conservative per-group remaining quota aggregation.
- Extend DB account selection to support group keys with `COALESCE(..., 0)` semantics to prevent phantom eligibility when group rows are missing.
- Add dynamic threshold resolution order:
  1. group-specific DB setting
  2. global DB setting
  3. group env default
  4. global env default
- Update retry/account-switch flow to work with group-aware sticky routing while preserving request-scoped exclusion in retry chains.
- Add dashboard API payload for routing overview and frontend card to show current account, sticky account, threshold, and quota per group.

## Validation
- Ran syntax checks with `node --check` on modified backend and frontend JS modules.
- Re-verified diffs across config, DB, routing, request handling, and dashboard UI paths for consistency.

## Notes
- Sticky pointer map is in-memory and resets on process restart.
- No schema migration required; existing `account_model_quotas` and `settings` tables are reused.